### PR TITLE
Field of view check

### DIFF
--- a/server/announce.js
+++ b/server/announce.js
@@ -19,19 +19,18 @@ function within_distance(
 }
 
 function get_user_angle(
-        user1_x, user1_y, user1_angle,
-        user2_x, user2_y
+        user2_x, user2_y, user2_angle,
+        user1_x, user1_y
     ) {
     // check if they are within their line of sight
     var user1and2Vector = new Vector();
-    user1and2Vector.fromTwoPoints([user1_x, user1_y], [user2_x, user2_y]);
-    var user1Vector = new Vector();
-    user1Vector.fromTwoPoints([user1_x, user1_y], [
-        user1_x + 1 * Math.cos(user1_angle),
-        user1_y + 1 * Math.sin(user1_angle)
-    ])
-    angle = user1and2Vector.angle(user1Vector);
-    return angle;
+    var user2Vector = new Vector();
+    user1and2Vector.fromTwoPoints([user2_x, user2_y], [user1_x, user1_y]);
+    user2Vector.fromTwoPoints([user2_x, user2_y], [
+        user2_x + 1 * Math.cos(user2_angle),
+        user2_y + 1 * Math.sin(user2_angle)
+    ]);
+    return user1and2Vector.angle(user2Vector);
 }
 
 function maybe_send_message(user1, user2, distance, check_behind, io, message) {
@@ -44,8 +43,8 @@ function maybe_send_message(user1, user2, distance, check_behind, io, message) {
     )
     
     var user_angle = get_user_angle(
-        user1["loc_x"], user1["loc_y"], user1["angle"],
-        user2["loc_x"], user2["loc_y"]
+        user2["loc_x"], user2["loc_y"], user2["angle"],
+        user1["loc_x"], user1["loc_y"]
     )
 
     // TODO: switch on user_angle to get 'far left', 'left', 'center', 'behind', etc

--- a/server/announce.js
+++ b/server/announce.js
@@ -25,12 +25,15 @@ function get_user_angle(
     // check if they are within their line of sight
     var user1and2Vector = new Vector();
     var user2Vector = new Vector();
-    user1and2Vector.fromTwoPoints([user2_x, user2_y], [user1_x, user1_y]);
-    user2Vector.fromTwoPoints([user2_x, user2_y], [
+    user1and2Vector.fromTwoPoints([user2_x, user2_y, 0], [user1_x, user1_y, 0]);
+    user2Vector.fromTwoPoints([user2_x, user2_y, 0], [
         user2_x + 1 * Math.cos(user2_angle),
-        user2_y + 1 * Math.sin(user2_angle)
+        user2_y + 1 * Math.sin(user2_angle),
+        0
     ]);
-    return user1and2Vector.angle(user2Vector);
+    var angle = user1and2Vector.angle(user2Vector);
+    var left_or_right = user1and2Vector.cross(user2Vector);
+    return left_or_right.toString() + ' ' + angle.toString();
 }
 
 function maybe_send_message(user1, user2, distance, check_behind, io, message) {

--- a/server/crud.js
+++ b/server/crud.js
@@ -75,7 +75,7 @@ async function move(socket_id, distance, turn) {
             socket_id: socket_id
         }, {
             $set: {
-                angle: user["angle"] + turn,
+                angle: (user["angle"] + turn) % (2 * Math.PI),
                 loc_x: user["loc_x"] + distance * Math.cos(user["angle"] + turn),
                 loc_y: user["loc_y"] + distance * Math.sin(user["angle"] + turn)
             }


### PR DESCRIPTION
## Description
Not perfect, but lays the foundation for observing other players

- add distance beyond which you can't see/hear someone
- you can hear players talk behind you, but you can't see players walk behind you
- when someone nearby walks/talks, the message indicates from what direction
- it also indicates how far left/right

## Follow-ups
- for GPU.js, do vector math without this library, it's not a very good vector library, and we don't do very complicated vector math anyways. We should just calculate it ourselves with the Math utility.
- check orientation of someone walking instead of copying their command (ex: "player walks to the left", when in reality they were facing to your left and walking forward)
- change the message to 'you see/hear the player to your left' instead of 'the player to your left walks'

## Testing
- one user walking around another user
- turning and then observing another player
- talking out of field of view, walking into field of view
```
The player behind you to the right say hello
The player to the far right of you walked forward
The player to the far right of you walked forward
The player to the right of you turned left
The player to the right of you walked forward
The player to the right of you walked forward
The player in front of you walked forward
The player to the left of you walked forward
```