### PR TITLE
Ttl enhancements

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -16,6 +16,7 @@ const EAST = 0;
 const WEST = Math.PI;
 const FIELD_OF_VIEW = Math.PI/2;
 const ONE_WEEK = 7 * 24 * 60 * 60 * 1000;
+const ALMOST_ONE_WEEK = 7 * 20 * 60 * 60 * 1000;
 
 module.exports = {
     SEEING_DISTANCE,
@@ -35,5 +36,6 @@ module.exports = {
     EAST,
     WEST,
     FIELD_OF_VIEW,
-    ONE_WEEK
+    ONE_WEEK,
+    ALMOST_ONE_WEEK
 }

--- a/server/crud/admin.js
+++ b/server/crud/admin.js
@@ -36,7 +36,43 @@ async function get_all_admins() {
 }
 
 async function email_admins_reports() {
-    // TODO
+    get_reports().catch(console.dir).then( (reports) => {
+
+        var report_data = `
+        <table>
+        <tbody>
+        <tr>
+        <td>Reporter</td>
+        <td>Reported</td>
+        <td>Date</td>
+        </tr>
+        `
+        reports.forEach( (report) => {
+            report_data += `
+            <tr>
+            <td>`+report['reporter']+`</td>
+            <td>`+report['reported']+`</td>
+            <td>`+report['ts']+`</td>
+            </tr>
+            `
+        }).then( () => {
+            report_data += `
+            </tbody>
+            </table>
+            `
+            get_all_admins().catch(console.dir).then( (admins) => {
+                admins.forEach( (admin) => {
+                    email_util.send_email(
+                        admin['email'],
+                        'Please review reported users',
+                        report_data
+                    );
+                }).then( () => {
+                    delete_reports();
+                });
+            });
+        });
+    });
 }
 
 async function email_admins_messages() {
@@ -75,7 +111,7 @@ async function email_admins_messages() {
                 }).then( () => {
                     delete_messages();
                 });
-            })
+            });
         })
     })
 }
@@ -157,4 +193,12 @@ async function report(email_reporter, email_reported) {
         reported: email_reported,
         ts: new Date()
     })
+}
+
+async function get_reports() {
+    return await db.collection('report').find({});
+}
+
+async function delete_reports() {
+    await db.collection('report').deleteMany({});
 }

--- a/server/crud/admin.js
+++ b/server/crud/admin.js
@@ -36,34 +36,32 @@ async function get_all_admins() {
 }
 
 async function email_admins_reports() {
-    Promise.all([
-        get_reports(),
-        get_all_admins()
-    ]).then(function(results) {
-        email_util.email_list(
-            results[1],
-            'Please review reported users',
-            ['Reporter', 'Reported', 'Date'],
-            ['reporter', 'reported', 'ts'],
-            results[0],
-            delete_reports
-        );
+    get_all_admins().then( (admins) => {
+        get_reports().then( (reports) => {
+            email_util.email_list(
+                admins,
+                'Please review reported users',
+                ['Reporter', 'Reported', 'Date'],
+                ['reporter', 'reported', 'ts'],
+                reports,
+                delete_reports
+            );
+        });
     });
 }
 
 async function email_admins_messages() {
-    Promise.all([
-        get_all_messages(),
-        get_all_admins()
-    ]).then(function(results) {
-        email_util.email_list(
-            results[1],
-            'Please review in game message',
-            ['Sender', 'Message', 'Date'],
-            ['sender', 'message', 'ts'],
-            results[0],
-            delete_messages
-        );
+    get_all_admins().then( (admins) => {
+        get_all_messages().then( (messages) => {
+            email_util.email_list(
+                admins,
+                'Please review in game message',
+                ['Sender', 'Message', 'Date'],
+                ['sender', 'message', 'ts'],
+                messages,
+                delete_messages
+            );
+        });
     });
 }
 

--- a/server/crud/admin.js
+++ b/server/crud/admin.js
@@ -36,84 +36,35 @@ async function get_all_admins() {
 }
 
 async function email_admins_reports() {
-    get_reports().catch(console.dir).then( (reports) => {
-
-        var report_data = `
-        <table>
-        <tbody>
-        <tr>
-        <td>Reporter</td>
-        <td>Reported</td>
-        <td>Date</td>
-        </tr>
-        `
-        reports.forEach( (report) => {
-            report_data += `
-            <tr>
-            <td>`+report['reporter']+`</td>
-            <td>`+report['reported']+`</td>
-            <td>`+report['ts']+`</td>
-            </tr>
-            `
-        }).then( () => {
-            report_data += `
-            </tbody>
-            </table>
-            `
-            get_all_admins().catch(console.dir).then( (admins) => {
-                admins.forEach( (admin) => {
-                    email_util.send_email(
-                        admin['email'],
-                        'Please review reported users',
-                        report_data
-                    );
-                }).then( () => {
-                    delete_reports();
-                });
-            });
-        });
+    Promise.all([
+        get_reports(),
+        get_all_admins()
+    ]).then(function(results) {
+        email_util.email_list(
+            results[1],
+            'Please review reported users',
+            ['Reporter', 'Reported', 'Date'],
+            ['reporter', 'reported', 'ts'],
+            results[0],
+            delete_reports
+        );
     });
 }
 
 async function email_admins_messages() {
-    get_all_messages().catch(console.dir).then( (messages) => {
-
-        var message_data = `
-        <table>
-        <tbody>
-        <tr>
-        <td>Sender</td>
-        <td>Message</td>
-        <td>Date</td>
-        </tr>
-        `
-        messages.forEach( (message) => {
-            message_data += `
-            <tr>
-            <td>`+message['sender']+`</td>
-            <td>`+message['message']+`</td>
-            <td>`+message['ts']+`</td>
-            </tr>
-            `
-        }).then( () => {
-            message_data += `
-            </tbody>
-            </table>
-            `
-
-            get_all_admins().catch(console.dir).then( (admins) => {
-                admins.forEach( (admin) => {
-                    email_util.send_email(
-                        admin['email'],
-                        'Please review in game messages',
-                        message_data
-                    );
-                }).then( () => {
-                    delete_messages();
-                });
-            });
-        })
-    })
+    Promise.all([
+        get_all_messages(),
+        get_all_admins()
+    ]).then(function(results) {
+        email_util.email_list(
+            results[1],
+            'Please review in game message',
+            ['Sender', 'Message', 'Date'],
+            ['sender', 'message', 'ts'],
+            results[0],
+            delete_messages
+        );
+    });
 }
 
 async function ban(email, io) {

--- a/server/crud/cron.js
+++ b/server/crud/cron.js
@@ -1,0 +1,19 @@
+const db = require('./db/db').get_db();
+const config = require('../config');
+
+module.exports = {
+    update_cron_ts,
+    last_ran_recently,
+};
+
+async function update_cron_ts() {
+    await db.collection('cron').updateOne({},{
+        $set: {last_run: new Date()}
+    });
+}
+
+async function last_ran_recently() {
+    return await db.collection('cron').findOne({
+        last_run: {$lt: new Date(new Date() - config.ALMOST_ONE_WEEK)}
+    });
+}

--- a/server/crud/metrics.js
+++ b/server/crud/metrics.js
@@ -7,23 +7,29 @@ module.exports = {
 }
 
 async function email_metrics() {
+
     Promise.all([
-        total_users_count(),
-        mailing_list_count(),
-        new_users_count(),
-        active_users_count(),
-        messages_count(),
-        corpse_count()
-    ]).then(function(metrics) {
-        email_util.email_list(
+        total_users_count(), mailing_list_count(), new_users_count(),
+        active_users_count(), messages_count(), corpse_count()
+    ]).then( (results) => {
+        email_util.email_list_2(
             [{email:'updates.textmmo@gmail.com'}],
             'Weekly Metrics',
             [
-                'Total Users', 'Users on the Mailing List', 'Active Users This Week',
-                'Messages Sent This Week', 'Corpses Created This Week'
+                'Total Users', 'Users on the Mailing List', 'New Users This Week',
+                'Active Users This Week', 'Messages Sent This Week', 'Corpses Created This Week'
             ],
             [0,1,2,3,4,5],
-            metrics,
+            [
+                {
+                    0: results[0],
+                    1: results[1],
+                    2: results[2],
+                    3: results[3],
+                    4: results[4],
+                    5: results[5]
+                }
+            ],
             false
         );
     });

--- a/server/crud/metrics.js
+++ b/server/crud/metrics.js
@@ -7,7 +7,6 @@ module.exports = {
 }
 
 async function email_metrics() {
-
     Promise.all([
         total_users_count(),
         mailing_list_count(),
@@ -16,30 +15,17 @@ async function email_metrics() {
         messages_count(),
         corpse_count()
     ]).then(function(metrics) {
-        var metrics = `
-            <table>
-            <tbody>
-            <tr>
-            <td>Total Users</td>
-            <td>Users on the Mailing List</td>
-            <td>New Users This Week</td>
-            <td>Active Users This Week</td>
-            <td>Messages Sent This Week</td>
-            <td>Corpses Created This Week</td>
-            </tr>
-            <tr>
-            <td>`+metrics[0]+`</td>
-            <td>`+metrics[1]+`</td>
-            <td>`+metrics[2]+`</td>
-            <td>`+metrics[3]+`</td>
-            <td>`+metrics[4]+`</td>
-            <td>`+metrics[5]+`</td>
-            </tr>
-            </tbody>
-            </table>
-        `
-
-        email_util.send_email('updates.textmmo@gmail.com', 'Weekly Metrics', metrics);
+        email_util.email_list(
+            [{email:'updates.textmmo@gmail.com'}],
+            'Weekly Metrics',
+            [
+                'Total Users', 'Users on the Mailing List', 'Active Users This Week',
+                'Messages Sent This Week', 'Corpses Created This Week'
+            ],
+            [0,1,2,3,4,5],
+            metrics,
+            false
+        );
     });
 }
 

--- a/server/crud/patch_notes.js
+++ b/server/crud/patch_notes.js
@@ -37,11 +37,18 @@ async function update_user_ts(socket_id) {
 }
 
 async function email_patch_notes() {
-    get_patch_notes_since_ts(
-        new Date(new Date() - config.ONE_WEEK)
-    ).catch(console.dir).then( (patches) => {
-        user.get_mailing_list().catch(console.dir).then( (users) => {
-            
-        });
+    Promise.all([
+        get_patch_notes_since_ts(new Date(new Date() - config.ONE_WEEK)),
+        user.get_mailing_list()
+    ]).then(function(results) {
+        if(results[0].length === 0) return;
+        email_util.email_list(
+            results[1],
+            'Here is what changed on TextMMO',
+            ['Patch Note', 'Date'],
+            ['note', 'ts'],
+            results[0],
+            false
+        );
     });
 }

--- a/server/crud/patch_notes.js
+++ b/server/crud/patch_notes.js
@@ -1,10 +1,14 @@
 const db = require('./db/db').get_db();
+const email_util = require('../utils/email');
+const user = require('./user/basic');
+const config = require('../config');
 
 module.exports = {
     add_patch_note,
     get_patch_notes_since_ts,
     get_recent_patch_notes,
-    update_user_ts
+    update_user_ts,
+    email_patch_notes
 };
 
 async function add_patch_note(custom_db, note) {
@@ -30,4 +34,14 @@ async function update_user_ts(socket_id) {
     }, {
         $set: {last_read_patch_notes: new Date()}
     })
+}
+
+async function email_patch_notes() {
+    get_patch_notes_since_ts(
+        new Date(new Date() - config.ONE_WEEK)
+    ).catch(console.dir).then( (patches) => {
+        user.get_mailing_list().catch(console.dir).then( (users) => {
+            
+        });
+    });
 }

--- a/server/crud/patch_notes.js
+++ b/server/crud/patch_notes.js
@@ -37,18 +37,18 @@ async function update_user_ts(socket_id) {
 }
 
 async function email_patch_notes() {
-    Promise.all([
-        get_patch_notes_since_ts(new Date(new Date() - config.ONE_WEEK)),
-        user.get_mailing_list()
-    ]).then(function(results) {
-        if(results[0].length === 0) return;
-        email_util.email_list(
-            results[1],
-            'Here is what changed on TextMMO',
-            ['Patch Note', 'Date'],
-            ['note', 'ts'],
-            results[0],
-            false
-        );
-    });
+    var patch_notes = get_patch_notes_since_ts(new Date(new Date() - config.ONE_WEEK));
+    var users = user.get_mailing_list();
+    patch_notes.then( (patch) => {
+        users.then( (user) => {
+            email_util.email_list(
+                user,
+                'Here is what changed on TextMMO',
+                ['Patch Note', 'Date'],
+                ['note', 'ts'],
+                patch,
+                false
+            );
+        })
+    })
 }

--- a/server/crud/terrain.js
+++ b/server/crud/terrain.js
@@ -71,7 +71,7 @@ async function check_biomes(socket_id, io, angle, lat, long) {
     var biome_ahead = look_at_biome(angle);
     var biome_right = look_at_biome(angle - Math.PI/2);
     var biome_left = look_at_biome(angle + Math.PI/2);
-    Promise.all([biome_ahead, biome_right, biome_left]).then(function(biomes) {
+    Promise.all([biome_ahead, biome_right, biome_left]).then( (biomes) => {
         get_biome(lat, long).catch(console.dir).then( (result) => {
             io.to(socket_id).emit('message', {
                 data: "You are in a " + result['biome'] + 

--- a/server/crud/user/basic.js
+++ b/server/crud/user/basic.js
@@ -5,7 +5,8 @@ module.exports = {
     get_user_by_email,
     check_mailing_list,
     unsubscribe,
-    subscribe
+    subscribe,
+    get_mailing_list
 }
 
 async function get_user(socket_id) {
@@ -33,6 +34,12 @@ async function check_mailing_list(email) {
     }, {
         mailing_list: 1, unsubscribe_code: 1
     })
+}
+
+async function get_mailing_list() {
+    return await db.collection('user').find({
+        mailing_list: true
+    }, {email: 1});
 }
 
 async function unsubscribe(email, code) {

--- a/server/main.js
+++ b/server/main.js
@@ -9,6 +9,7 @@ const rateLimit = require('express-rate-limit')
 const user = require('./crud/user/basic');
 const metrics = require('./crud/metrics');
 const admin = require('./crud/admin');
+const patch_notes = require('./crud/patch_notes');
 
 const limiter = rateLimit({
 	windowMs: 15 * 60 * 1000, // 15 minutes
@@ -62,6 +63,7 @@ app.get("/ttl", (req, res) => {
   metrics.email_metrics().then( () => {
     admin.email_admins_messages();
     admin.email_admins_reports();
+    patch_notes.email_patch_notes();
   })
 });
 

--- a/server/main.js
+++ b/server/main.js
@@ -8,6 +8,7 @@ const path = require('path');
 const rateLimit = require('express-rate-limit')
 const user = require('./crud/user/basic');
 const metrics = require('./crud/metrics');
+const admin = require('./crud/admin');
 
 const limiter = rateLimit({
 	windowMs: 15 * 60 * 1000, // 15 minutes
@@ -59,13 +60,8 @@ app.get("/ttl", (req, res) => {
   res.sendStatus(200);
   console.log("Running TTL");
   metrics.email_metrics().then( () => {
-    // TODO
-
-    // delete old corpses
-
-    // delete old messages in the message table
-
-    // delete old reports
+    admin.email_admins_messages();
+    admin.email_admins_reports();
   })
 });
 

--- a/server/migrations/1656182113454_messagetime.js
+++ b/server/migrations/1656182113454_messagetime.js
@@ -1,0 +1,46 @@
+
+
+const custom_db = require('../crud/db/custom_db')
+
+module.exports = {
+    up,
+    down
+}
+
+function up(env) {
+    console.log("Running on: " + env);
+    const db = custom_db.get_db(env);
+    // write migration here
+}
+
+function down(env) {
+    console.log("Running on: " + env);
+    const db = custom_db.get_db(env);
+    // how to undo the migration here
+}
+
+function up(env) {
+    console.log("Running on: " + env);
+    const db = custom_db.get_db(env);
+    db.collection('message').updateMany({}, {
+        $set: {
+            ts: new Date(),
+        }
+    }).then( () => {
+        console.log("done");
+        process.exit(0);
+    })
+}
+
+function down(env) {
+    console.log("Running on: " + env);
+    const db = custom_db.get_db(env);
+    db.collection('message').updateMany({}, {
+        $set: {
+            ts: new Date(),
+        }
+    }).then( () => {
+        console.log("done");
+        process.exit(0);
+    })
+}

--- a/server/migrations/1656197117638_cronruns.js
+++ b/server/migrations/1656197117638_cronruns.js
@@ -1,0 +1,30 @@
+
+const custom_db = require('../crud/db/custom_db')
+const config = require('../config');
+
+module.exports = {
+    up,
+    down
+}
+
+function up(env) {
+    console.log("Running on: " + env);
+    const db = custom_db.get_db(env);
+    db.createCollection('cron').catch(console.dir).then( () => {
+        db.collection('cron').insertOne(
+            {"last_run":  new Date(new Date() - config.ONE_WEEK)}
+        ).then( () => {
+            console.log("done");
+            process.exit(0);
+        })
+    });
+}
+
+function down(env) {
+    console.log("Running on: " + env);
+    const db = custom_db.get_db(env);
+    db.dropCollection('cron').catch(console.dir).then( () => {
+        console.log("done");
+        process.exit(0);
+    });
+}

--- a/server/scripts/run_migration.js
+++ b/server/scripts/run_migration.js
@@ -13,7 +13,7 @@ const migration = require("../migrations/" + migration_file[0]);
 if(process.argv[3] === "up") {
     migration.up(process.argv[4]);
 } else if(process.argv[3] === "down") {
-    migrataion.down(process.argv[4]);
+    migration.down(process.argv[4]);
 } else {
     console.log("Error! Call this script like this: node run_migration.js <migration_name> <up|down> <prod|dev>");
 }

--- a/server/utils/email.js
+++ b/server/utils/email.js
@@ -4,7 +4,8 @@ const user = require('../crud/user/basic');
 const nodemailer = require('nodemailer');
 
 module.exports = {
-    send_email
+    send_email,
+    email_list
 };
 
 var transporter = nodemailer.createTransport({
@@ -35,4 +36,40 @@ function send_email(email, subject, text) {
             }
         });
     })
+}
+
+function email_list(recipients, subject, table_headers, table_data, callback) {
+    // build table
+    var email_table = "<table><tbody><tr>";
+
+    // add header row
+    for(var i = 0; i < table_headers.length; i++) {
+        email_table += "<td>" + table_headers[i] + "</td>";
+    }
+    email_table += "</tr>";
+
+    // add data rows
+    for(var i = 0; i < table_data.length; i++) {
+        email_table += "<tr>";
+        for(var ii = 0; ii < table_headers.length; ii++) {
+            email_table += "<td>" + table_data[i][table_headers[ii]] + "</td>";
+        }
+        email_table += "<\tr>";
+    }
+    email_table += `
+    </tbody>
+    </table>
+    `;
+
+    // send emails
+    recipients.forEach( (user) => {
+        send_email(
+            user['email'],
+            subject,
+            email_table
+        );
+    });
+
+    // delete data when finished
+    if(callback) callback();
 }

--- a/server/utils/email.js
+++ b/server/utils/email.js
@@ -38,21 +38,21 @@ function send_email(email, subject, text) {
     })
 }
 
-function email_list(recipients, subject, table_headers, table_data, callback) {
+function email_list(recipients, subject, headers_text, headers, table_data, callback) {
     // build table
     var email_table = "<table><tbody><tr>";
 
     // add header row
-    for(var i = 0; i < table_headers.length; i++) {
-        email_table += "<td>" + table_headers[i] + "</td>";
+    for(var i = 0; i < headers_text.length; i++) {
+        email_table += "<td>" + headers_text[i] + "</td>";
     }
     email_table += "</tr>";
 
     // add data rows
     for(var i = 0; i < table_data.length; i++) {
         email_table += "<tr>";
-        for(var ii = 0; ii < table_headers.length; ii++) {
-            email_table += "<td>" + table_data[i][table_headers[ii]] + "</td>";
+        for(var ii = 0; ii < headers.length; ii++) {
+            email_table += "<td>" + table_data[i][headers[ii]] + "</td>";
         }
         email_table += "<\tr>";
     }

--- a/server/utils/email.js
+++ b/server/utils/email.js
@@ -5,7 +5,8 @@ const nodemailer = require('nodemailer');
 
 module.exports = {
     send_email,
-    email_list
+    email_list,
+    email_list_2
 };
 
 var transporter = nodemailer.createTransport({
@@ -40,22 +41,58 @@ function send_email(email, subject, text) {
 
 function email_list(recipients, subject, headers_text, headers, table_data, callback) {
     // build table
-    var email_table = "<table><tbody><tr>";
+    var email_table = "<table style=\"border: 1px solid black;\"><tbody><tr style=\"border: 1px solid black;\">";
 
     // add header row
-    for(var i = 0; i < headers_text.length; i++) {
-        email_table += "<td>" + headers_text[i] + "</td>";
+    for(var header of headers_text) {
+        email_table += "<td style=\"border: 1px solid black;\">" + header + "</td>";
     }
     email_table += "</tr>";
 
-    // add data rows
-    for(var i = 0; i < table_data.length; i++) {
-        email_table += "<tr>";
-        for(var ii = 0; ii < headers.length; ii++) {
-            email_table += "<td>" + table_data[i][headers[ii]] + "</td>";
+    table_data.forEach( (row) => {
+        email_table += "<tr style=\"border: 1px solid black;\">";
+        for(var header of headers) {
+            email_table += "<td style=\"border: 1px solid black;\">" + row[header] + "</td>";
         }
-        email_table += "<\tr>";
+        email_table += "</tr>";
+    }).then( () => {
+        email_table += `
+        </tbody>
+        </table>
+        `;
+    
+        // send emails
+        recipients.forEach( (user) => {
+            send_email(
+                user['email'],
+                subject,
+                email_table
+            );
+        });
+    
+        // delete data when finished
+        if(callback) callback();
+    });
+}
+
+function email_list_2(recipients, subject, headers_text, headers, table_data, callback) {
+    // build table
+    var email_table = "<table style=\"border: 1px solid black;\"><tbody><tr style=\"border: 1px solid black;\">";
+
+    // add header row
+    for(var header of headers_text) {
+        email_table += "<td style=\"border: 1px solid black;\">" + header + "</td>";
     }
+    email_table += "</tr>";
+
+    for(var i = 0; i < table_data.length; i++) {
+        email_table += "<tr style=\"border: 1px solid black;\">";
+        for(var header of headers) {
+            email_table += "<td style=\"border: 1px solid black;\">" + table_data[i][header] + "</td>";
+        }
+        email_table += "</tr>";
+    }
+
     email_table += `
     </tbody>
     </table>


### PR DESCRIPTION
## Description
- Email admins about messages sent in the past week and user reports
- Email users patch note updates weekly
- Added border formatting for email tables
- Added db restriction to prevent ttl/cron from running more than once per week. This way if someone finds or spams the ttl endpoint it won't email all the users and prematurely delete data.
- Tried to consolidate emailing a list of users into a utility, but ran into some issues with the metrics one, so it's a bit messy with 2 utilities doing almost the same thing. It was too difficult to fix so I left it for now.

No user facing changes so I won't create a new release

## Testing Methods

## Risks

## Merging Checklist
- [ ] Wiki updated
- [ ] Patch notes updated in mongo `node server/scripts/patch_note_util.js PROD "example patch note that describes updates to users"`
- [ ] (After merging) Create a new github release with the same patch note
- [ ] package.json version updated
- [x] Migration created and executed
